### PR TITLE
Optimize project performance

### DIFF
--- a/Media/Common/View/Media Cell/MKCBasicMediaTableViewCell.m
+++ b/Media/Common/View/Media Cell/MKCBasicMediaTableViewCell.m
@@ -37,6 +37,8 @@
 	// 取消之前的圖片載入請求，避免 cell 重用時載入錯誤的圖片
 	[self.coverImageView sd_cancelCurrentImageLoad];
 	self.coverImageView.image = nil;
+	// 重置背景色，避免重用時顯示錯誤的背景色
+	self.coverImageView.backgroundColor = [UIColor lightGrayColor];
 }
 
 #pragma mark - binding

--- a/Media/Common/View/Media Cell/MKCBasicMediaTableViewCell.m
+++ b/Media/Common/View/Media Cell/MKCBasicMediaTableViewCell.m
@@ -32,6 +32,13 @@
 	
 }
 
+- (void)prepareForReuse {
+	[super prepareForReuse];
+	// 取消之前的圖片載入請求，避免 cell 重用時載入錯誤的圖片
+	[self.coverImageView sd_cancelCurrentImageLoad];
+	self.coverImageView.image = nil;
+}
+
 #pragma mark - binding
 
 - (void)setIsCollected:(BOOL)isCollected {

--- a/Media/Common/View/Media Cell/MKCMovieTableViewCell.m
+++ b/Media/Common/View/Media Cell/MKCMovieTableViewCell.m
@@ -51,12 +51,14 @@
 
 - (void)configureWithModel:(JSONModel *)model {
 	MKCMovieInfoModel *movie = (MKCMovieInfoModel *)model;
+	NSURL *expectedURL = [NSURL URLWithString:movie.imageUrl];
 	// 優化圖片載入：使用 SDWebImage 的緩存策略和錯誤處理
-	[self.coverImageView sd_setImageWithURL:[NSURL URLWithString:movie.imageUrl]
+	[self.coverImageView sd_setImageWithURL:expectedURL
 							placeholderImage:nil
 									 options:SDWebImageRetryFailed | SDWebImageHighPriority
 								   completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
-		if (error) {
+		// 檢查 URL 是否匹配，避免 cell 重用時設置錯誤的背景色
+		if (error && [imageURL isEqual:expectedURL]) {
 			// 載入失敗時使用預設背景色
 			self.coverImageView.backgroundColor = [UIColor lightGrayColor];
 		}

--- a/Media/Common/View/Media Cell/MKCMovieTableViewCell.m
+++ b/Media/Common/View/Media Cell/MKCMovieTableViewCell.m
@@ -51,7 +51,16 @@
 
 - (void)configureWithModel:(JSONModel *)model {
 	MKCMovieInfoModel *movie = (MKCMovieInfoModel *)model;
-	[self.coverImageView sd_setImageWithURL:[NSURL URLWithString:movie.imageUrl]];
+	// 優化圖片載入：使用 SDWebImage 的緩存策略和錯誤處理
+	[self.coverImageView sd_setImageWithURL:[NSURL URLWithString:movie.imageUrl]
+							placeholderImage:nil
+									 options:SDWebImageRetryFailed | SDWebImageHighPriority
+								   completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
+		if (error) {
+			// 載入失敗時使用預設背景色
+			self.coverImageView.backgroundColor = [UIColor lightGrayColor];
+		}
+	}];
 	self.trackName = movie.trackName;
 	self.artistName = movie.artistName;
 	self.trackCensoredName = movie.trackCensoredName;

--- a/Media/Common/View/Media Cell/MKCSongTableViewCell.m
+++ b/Media/Common/View/Media Cell/MKCSongTableViewCell.m
@@ -43,7 +43,16 @@
 
 - (void)configureWithModel:(JSONModel *)model {
 	MKCSongInfoModel *song = (MKCSongInfoModel *)model;
-	[self.coverImageView sd_setImageWithURL:[NSURL URLWithString:song.imageUrl]];
+	// 優化圖片載入：使用 SDWebImage 的緩存策略和錯誤處理
+	[self.coverImageView sd_setImageWithURL:[NSURL URLWithString:song.imageUrl]
+							placeholderImage:nil
+									 options:SDWebImageRetryFailed | SDWebImageHighPriority
+								   completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
+		if (error) {
+			// 載入失敗時使用預設背景色
+			self.coverImageView.backgroundColor = [UIColor lightGrayColor];
+		}
+	}];
 	self.trackName = song.trackName;
 	self.artistName = song.artistName;
 	self.collectionName = song.collectionName;

--- a/Media/Common/View/Media Cell/MKCSongTableViewCell.m
+++ b/Media/Common/View/Media Cell/MKCSongTableViewCell.m
@@ -43,12 +43,14 @@
 
 - (void)configureWithModel:(JSONModel *)model {
 	MKCSongInfoModel *song = (MKCSongInfoModel *)model;
+	NSURL *expectedURL = [NSURL URLWithString:song.imageUrl];
 	// 優化圖片載入：使用 SDWebImage 的緩存策略和錯誤處理
-	[self.coverImageView sd_setImageWithURL:[NSURL URLWithString:song.imageUrl]
+	[self.coverImageView sd_setImageWithURL:expectedURL
 							placeholderImage:nil
 									 options:SDWebImageRetryFailed | SDWebImageHighPriority
 								   completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
-		if (error) {
+		// 檢查 URL 是否匹配，避免 cell 重用時設置錯誤的背景色
+		if (error && [imageURL isEqual:expectedURL]) {
 			// 載入失敗時使用預設背景色
 			self.coverImageView.backgroundColor = [UIColor lightGrayColor];
 		}

--- a/Media/Data Persistence/MKCDataPersistence.m
+++ b/Media/Data Persistence/MKCDataPersistence.m
@@ -16,7 +16,49 @@ NSString *const MKCCollectedMoviesKey = @"MKCCollectedMoviesKey";
 NSString *const MKCCollectedSongsKey = @"MKCCollectedSongsKey";
 NSString *const MKCThemeKey = @"MKCThemeKey";
 
+@interface MKCDataPersistence ()
+
+@property (class, nonatomic, strong) NSSet<NSString *> *cachedCollectedMovieTrackIds;
+@property (class, nonatomic, strong) NSSet<NSString *> *cachedCollectedSongTrackIds;
+
+@end
+
 @implementation MKCDataPersistence
+
+static NSSet<NSString *> *_cachedCollectedMovieTrackIds = nil;
+static NSSet<NSString *> *_cachedCollectedSongTrackIds = nil;
+
++ (NSSet<NSString *> *)cachedCollectedMovieTrackIds {
+	if (!_cachedCollectedMovieTrackIds) {
+		[self reloadCachedCollectedMovieTrackIds];
+	}
+	return _cachedCollectedMovieTrackIds;
+}
+
++ (void)setCachedCollectedMovieTrackIds:(NSSet<NSString *> *)cachedCollectedMovieTrackIds {
+	_cachedCollectedMovieTrackIds = cachedCollectedMovieTrackIds;
+}
+
++ (NSSet<NSString *> *)cachedCollectedSongTrackIds {
+	if (!_cachedCollectedSongTrackIds) {
+		[self reloadCachedCollectedSongTrackIds];
+	}
+	return _cachedCollectedSongTrackIds;
+}
+
++ (void)setCachedCollectedSongTrackIds:(NSSet<NSString *> *)cachedCollectedSongTrackIds {
+	_cachedCollectedSongTrackIds = cachedCollectedSongTrackIds;
+}
+
++ (void)reloadCachedCollectedMovieTrackIds {
+	NSArray<NSString *> *trackIds = [self.userDefaults arrayForKey:MKCCollectedMoviesKey] ?: @[];
+	_cachedCollectedMovieTrackIds = [NSSet setWithArray:trackIds];
+}
+
++ (void)reloadCachedCollectedSongTrackIds {
+	NSArray<NSString *> *trackIds = [self.userDefaults arrayForKey:MKCCollectedSongsKey] ?: @[];
+	_cachedCollectedSongTrackIds = [NSSet setWithArray:trackIds];
+}
 
 + (NSUserDefaults *)userDefaults {
 	return [NSUserDefaults standardUserDefaults];
@@ -32,23 +74,28 @@ NSString *const MKCThemeKey = @"MKCThemeKey";
 
 + (void)collectMovieWithTrackId:(NSString *)trackId {
 	NSMutableArray *collectedMovies = [self.userDefaults mutableArrayValueForKey:MKCCollectedMoviesKey];
-	[collectedMovies addObject:trackId];
-	[self.userDefaults setObject:[collectedMovies copy] forKey:MKCCollectedMoviesKey];
-	
-	[[NSNotificationCenter defaultCenter] postNotificationName:MKCCollectedMovieDidChangeNotification object:nil];
+	if (![collectedMovies containsObject:trackId]) {
+		[collectedMovies addObject:trackId];
+		[self.userDefaults setObject:[collectedMovies copy] forKey:MKCCollectedMoviesKey];
+		[self reloadCachedCollectedMovieTrackIds];
+		
+		[[NSNotificationCenter defaultCenter] postNotificationName:MKCCollectedMovieDidChangeNotification object:nil];
+	}
 }
 
 + (void)removeCollectedMovieWithTrackId:(NSString *)trackId {
 	NSMutableArray *collectedMovies = [self.userDefaults mutableArrayValueForKey:MKCCollectedMoviesKey];
-	[collectedMovies removeObject:trackId];
-	[self.userDefaults setObject:[collectedMovies copy] forKey:MKCCollectedMoviesKey];
-	
-	[[NSNotificationCenter defaultCenter] postNotificationName:MKCCollectedMovieDidChangeNotification object:nil];
+	if ([collectedMovies containsObject:trackId]) {
+		[collectedMovies removeObject:trackId];
+		[self.userDefaults setObject:[collectedMovies copy] forKey:MKCCollectedMoviesKey];
+		[self reloadCachedCollectedMovieTrackIds];
+		
+		[[NSNotificationCenter defaultCenter] postNotificationName:MKCCollectedMovieDidChangeNotification object:nil];
+	}
 }
 
 + (BOOL)hasCollectdMovieWithTrackId:(NSString *)trackId {
-	NSMutableArray *collectedMovies = [self.userDefaults mutableArrayValueForKey:MKCCollectedMoviesKey];
-	return [collectedMovies containsObject:trackId];
+	return [[self cachedCollectedMovieTrackIds] containsObject:trackId];
 }
 
 + (NSArray<NSString *> *)collectMovieTrackIds {
@@ -60,23 +107,28 @@ NSString *const MKCThemeKey = @"MKCThemeKey";
 
 + (void)collectSongWithTrackId:(nonnull NSString *)trackId {
 	NSMutableArray *collectedSongs = [self.userDefaults mutableArrayValueForKey:MKCCollectedSongsKey];
-	[collectedSongs addObject:trackId];
-	[self.userDefaults setObject:[collectedSongs copy] forKey:MKCCollectedSongsKey];
-	
-	[[NSNotificationCenter defaultCenter] postNotificationName:MKCCollectedSongDidChangeNotification object:nil];
+	if (![collectedSongs containsObject:trackId]) {
+		[collectedSongs addObject:trackId];
+		[self.userDefaults setObject:[collectedSongs copy] forKey:MKCCollectedSongsKey];
+		[self reloadCachedCollectedSongTrackIds];
+		
+		[[NSNotificationCenter defaultCenter] postNotificationName:MKCCollectedSongDidChangeNotification object:nil];
+	}
 }
 
 + (void)removeCollectedSongWithTrackId:(nonnull NSString *)trackId {
 	NSMutableArray *collectedSongs = [self.userDefaults mutableArrayValueForKey:MKCCollectedSongsKey];
-	[collectedSongs removeObject:trackId];
-	[self.userDefaults setObject:[collectedSongs copy] forKey:MKCCollectedSongsKey];
-	
-	[[NSNotificationCenter defaultCenter] postNotificationName:MKCCollectedSongDidChangeNotification object:nil];
+	if ([collectedSongs containsObject:trackId]) {
+		[collectedSongs removeObject:trackId];
+		[self.userDefaults setObject:[collectedSongs copy] forKey:MKCCollectedSongsKey];
+		[self reloadCachedCollectedSongTrackIds];
+		
+		[[NSNotificationCenter defaultCenter] postNotificationName:MKCCollectedSongDidChangeNotification object:nil];
+	}
 }
 
 + (BOOL)hasCollectdSongWithTrackId:(nonnull NSString *)trackId {
-	NSMutableArray *collectedSongs = [self.userDefaults mutableArrayValueForKey:MKCCollectedSongsKey];
-	return [collectedSongs containsObject:trackId];
+	return [[self cachedCollectedSongTrackIds] containsObject:trackId];
 }
 
 + (NSArray<NSString *> *)collectSongTrackIds {

--- a/Media/My Collection/MKCCollectedMoviesViewController.m
+++ b/Media/My Collection/MKCCollectedMoviesViewController.m
@@ -45,13 +45,22 @@
 	MKCMovieTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:MKCMovieTableViewCell.identifier forIndexPath:indexPath];
 	
 	MKCMovieInfoModel *movieInfo = self.movies[indexPath.row];
-	[cell.coverImageView sd_setImageWithURL:[NSURL URLWithString:movieInfo.imageUrl]];
+	// 優化圖片載入：使用 SDWebImage 的緩存策略和錯誤處理
+	[cell.coverImageView sd_setImageWithURL:[NSURL URLWithString:movieInfo.imageUrl]
+							placeholderImage:nil
+									 options:SDWebImageRetryFailed | SDWebImageHighPriority
+								   completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
+		if (error) {
+			cell.coverImageView.backgroundColor = [UIColor lightGrayColor];
+		}
+	}];
 	cell.trackName = movieInfo.trackName;
 	cell.artistName = movieInfo.artistName;
 	cell.trackCensoredName = movieInfo.trackCensoredName;
 	cell.duration = movieInfo.trackTime;
 	cell.longDescription = movieInfo.longDescription;
-	cell.isCollected = [MKCDataPersistence hasCollectdMovieWithTrackId:movieInfo.trackId];
+	// 由於此頁面只顯示已收藏的項目，直接設為 YES，避免重複查詢
+	cell.isCollected = YES;
 	cell.isCollapsed = ![self.expandMovieItems containsObject:movieInfo.trackId];
 	
 	cell.delegate = self;

--- a/Media/My Collection/MKCCollectedMoviesViewController.m
+++ b/Media/My Collection/MKCCollectedMoviesViewController.m
@@ -45,12 +45,14 @@
 	MKCMovieTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:MKCMovieTableViewCell.identifier forIndexPath:indexPath];
 	
 	MKCMovieInfoModel *movieInfo = self.movies[indexPath.row];
+	NSURL *expectedURL = [NSURL URLWithString:movieInfo.imageUrl];
 	// 優化圖片載入：使用 SDWebImage 的緩存策略和錯誤處理
-	[cell.coverImageView sd_setImageWithURL:[NSURL URLWithString:movieInfo.imageUrl]
+	[cell.coverImageView sd_setImageWithURL:expectedURL
 							placeholderImage:nil
 									 options:SDWebImageRetryFailed | SDWebImageHighPriority
 								   completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
-		if (error) {
+		// 檢查 URL 是否匹配，避免 cell 重用時設置錯誤的背景色
+		if (error && [imageURL isEqual:expectedURL]) {
 			cell.coverImageView.backgroundColor = [UIColor lightGrayColor];
 		}
 	}];

--- a/Media/My Collection/MKCCollectedSongsViewController.m
+++ b/Media/My Collection/MKCCollectedSongsViewController.m
@@ -44,12 +44,21 @@
 	MKCSongTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:MKCSongTableViewCell.identifier forIndexPath:indexPath];
 	
 	MKCSongInfoModel *songInfo = self.songs[indexPath.row];
-	[cell.coverImageView sd_setImageWithURL:[NSURL URLWithString:songInfo.imageUrl]];
+	// 優化圖片載入：使用 SDWebImage 的緩存策略和錯誤處理
+	[cell.coverImageView sd_setImageWithURL:[NSURL URLWithString:songInfo.imageUrl]
+							placeholderImage:nil
+									 options:SDWebImageRetryFailed | SDWebImageHighPriority
+								   completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
+		if (error) {
+			cell.coverImageView.backgroundColor = [UIColor lightGrayColor];
+		}
+	}];
 	cell.trackName = songInfo.trackName;
 	cell.artistName = songInfo.artistName;
 	cell.collectionName = songInfo.collectionName;
 	cell.duration = songInfo.trackTime;
-	cell.isCollected = [MKCDataPersistence hasCollectdSongWithTrackId:songInfo.trackId];
+	// 由於此頁面只顯示已收藏的項目，直接設為 YES，避免重複查詢
+	cell.isCollected = YES;
 	
 	cell.delegate = self;
 	cell.tag = indexPath.row;

--- a/Media/Search/MKCSearchViewController.m
+++ b/Media/Search/MKCSearchViewController.m
@@ -29,6 +29,8 @@ typedef NS_ENUM(NSInteger, MKCMediaType) {
 @property (nonatomic, strong) NSMutableDictionary<NSNumber *, NSArray<JSONModel *> *> *mediaElements;
 @property (nonatomic, strong) NSArray<NSNumber *> *cellListOrder;
 @property (nonatomic, strong) NSMutableSet<NSString *> *expandedMovieItems;
+@property (nonatomic, strong) NSSet<NSString *> *collectedMovieTrackIds;
+@property (nonatomic, strong) NSSet<NSString *> *collectedSongTrackIds;
 
 @end
 
@@ -113,6 +115,10 @@ typedef NS_ENUM(NSInteger, MKCMediaType) {
 - (void)parseData {
 	self.mediaElements = [[NSMutableDictionary alloc] init];
 	
+	// 一次性載入所有收藏狀態，避免在 cellForRowAtIndexPath 中重複查詢
+	self.collectedMovieTrackIds = [NSSet setWithArray:[MKCDataPersistence collectMovieTrackIds]];
+	self.collectedSongTrackIds = [NSSet setWithArray:[MKCDataPersistence collectSongTrackIds]];
+	
 	[self.cellListOrder enumerateObjectsUsingBlock:^(NSNumber * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
 		MKCMediaType type = (MKCMediaType)obj.integerValue;
 		
@@ -132,7 +138,7 @@ typedef NS_ENUM(NSInteger, MKCMediaType) {
 - (MKCMovieTableViewCell *)setupMovieTableViewCellWithCell:(MKCBasicMediaTableViewCell *)cell cellModel:(MKCMovieInfoModel *)cellModel {
 	MKCMovieTableViewCell *movieCell = (MKCMovieTableViewCell *)cell;
 	movieCell.delegate = self;
-	movieCell.isCollected = [MKCDataPersistence hasCollectdMovieWithTrackId:cellModel.trackId];
+	movieCell.isCollected = [self.collectedMovieTrackIds containsObject:cellModel.trackId];
 	movieCell.isCollapsed = ![self.expandedMovieItems containsObject:cellModel.trackId];
 	return movieCell;
 }
@@ -140,7 +146,7 @@ typedef NS_ENUM(NSInteger, MKCMediaType) {
 - (MKCSongTableViewCell *)setupSongTableViewCellWithCell:(MKCBasicMediaTableViewCell *)cell cellModel:(MKCSongInfoModel *)cellModel {
 	MKCSongTableViewCell *songCell = (MKCSongTableViewCell *)cell;
 	songCell.delegate = self;
-	songCell.isCollected = [MKCDataPersistence hasCollectdSongWithTrackId:cellModel.trackId];
+	songCell.isCollected = [self.collectedSongTrackIds containsObject:cellModel.trackId];
 	return songCell;
 }
 
@@ -394,6 +400,10 @@ typedef NS_ENUM(NSInteger, MKCMediaType) {
 	if (self.tabBarController.selectedIndex == 0) {
 		return;
 	}
+	
+	// 重新載入收藏狀態
+	self.collectedMovieTrackIds = [NSSet setWithArray:[MKCDataPersistence collectMovieTrackIds]];
+	self.collectedSongTrackIds = [NSSet setWithArray:[MKCDataPersistence collectSongTrackIds]];
 	
 	NSArray *visibleIndexPaths = [self.tableView indexPathsForVisibleRows];
 	[self.tableView reloadRowsAtIndexPaths:visibleIndexPaths withRowAnimation:UITableViewRowAnimationNone];


### PR DESCRIPTION
Optimized performance by using `NSSet` for O(1) collection status checks, caching collected item IDs to reduce `NSUserDefaults` lookups, and improving image loading and cell reuse in table views.

---
<a href="https://cursor.com/background-agent?bcId=bc-29108698-7455-4638-bbf9-7f07c265a0c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-29108698-7455-4638-bbf9-7f07c265a0c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Caches collected track IDs and optimizes image loading/reuse to reduce lookups, prevent wrong images on reuse, and streamline isCollected checks.
> 
> - **Data persistence (`MKCDataPersistence`)**:
>   - Add cached `NSSet` for `movie`/`song` collected track IDs with reload helpers; `hasCollectd*` now uses cache for O(1) checks.
>   - Guard add/remove to avoid duplicates, update cache, and only then post change notifications.
> - **UI cells**:
>   - `MKCBasicMediaTableViewCell`: implement `prepareForReuse` to cancel SDWebImage requests and clear images.
>   - `MKCMovieTableViewCell` / `MKCSongTableViewCell`: use `sd_setImageWithURL` with retry/high-priority options and error fallback background.
> - **Search (`MKCSearchViewController`)**:
>   - Preload `collectedMovieTrackIds`/`collectedSongTrackIds` once in `parseData` and use to set `isCollected`.
>   - On collect change notifications, refresh the cached sets and reload visible rows.
> - **My Collection views**:
>   - `MKCCollectedMoviesViewController` / `MKCCollectedSongsViewController`: set `isCollected = YES` for cells; adopt optimized image loading.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dab641fbce83a05ce8445656ea3baf3bd410232a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->