### PR TITLE
移除用不到的程式碼

### DIFF
--- a/Media/AppDelegate.m
+++ b/Media/AppDelegate.m
@@ -28,10 +28,6 @@
 	self.window.rootViewController = mainTabBarController;
 	[self.window makeKeyAndVisible];
 	
-	[MKCDataPersistence setDefaultValue];
-	
-	[MKCThemeManager applyTheme:MKCDataPersistence.theme];
-	
 	return YES;
 }
 

--- a/Media/AppDelegate.m
+++ b/Media/AppDelegate.m
@@ -21,6 +21,9 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 	// Override point for customization after application launch.
 	
+	[MKCDataPersistence setDefaultValue];
+	[MKCThemeManager applyTheme:[MKCDataPersistence theme]];
+	
 	self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
 	
 	MKCMainTabBarController *mainTabBarController = [[MKCMainTabBarController alloc] init];


### PR DESCRIPTION
移除用不到的程式碼

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes unused persistence/theme setup from `AppDelegate` launch sequence.
> 
> - **iOS App Launch**:
>   - Remove unused initialization in `Media/AppDelegate.m` `application:didFinishLaunchingWithOptions:`:
>     - Delete `MKCDataPersistence setDefaultValue` call.
>     - Delete `MKCThemeManager applyTheme:MKCDataPersistence.theme` call.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24b079a404a56c51507c719018cbf8cee66b4696. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->